### PR TITLE
Remove the time crate, use existing chrono crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ log = "0.3"
 num = "0.1"
 rustc-serialize = "0.3"
 tempdir = "0.3"
-time = "0.1"
 
 [[bin]]
 name = "sbd"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ extern crate glob;
 #[macro_use] extern crate log;
 extern crate num;
 extern crate tempdir;
-extern crate time;
 
 use std::result;
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,8 +9,9 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
+use chrono::UTC;
+
 use log::{Log, LogLevel, LogLevelFilter, LogMetadata, LogRecord, set_logger, SetLoggerError};
-use time;
 
 pub fn init<P: 'static + AsRef<Path> + Send + Sync>(path: P) -> Result<(), SetLoggerError> {
     set_logger(|max_log_level| {
@@ -42,7 +43,7 @@ impl<P: AsRef<Path> + Send + Sync> Log for Logger<P> {
                 .write(true)
                 .append(true)
                 .open(&self.path).unwrap();
-            file.write_all(format!("({}) {}: {}\n", time::now_utc().strftime("%Y-%m-%d %H:%M:%S").unwrap(),
+            file.write_all(format!("({}) {}: {}\n", UTC::now().format("%Y-%m-%d %H:%M:%S"),
                 record.level(), record.args()).as_bytes()).unwrap();
         }
     }


### PR DESCRIPTION
When I was putting together the Logger I forgot that I already had
`chrono` for time management. This commit switches to the chrono crate.
