### PR TITLE
sbd payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `payload` command ([#21](https://github.com/gadomski/sbd-rs/pull/21))
+
 ## [0.3.1] - 2022-10-10
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,19 @@ fn main() {
         }
     }
     if args.cmd_payload {
-        unimplemented!()
+        match Message::from_path(&args.arg_file) {
+            Ok(ref message) => match str::from_utf8(message.payload()) {
+                Ok(content) => println!("{}", content),
+                Err(err) => {
+                    println!("ERROR: Unable to parse paylode as UTF-8: {}", err);
+                    process::exit(1);
+                }
+            },
+            Err(err) => {
+                println!("ERROR: Unable to read message: {}", err);
+                process::exit(1);
+            }
+        }
     }
     if args.cmd_serve {
         let logger = Logger {


### PR DESCRIPTION
In response to #19. Reimplement as it was before. Since the payload does not necessarily conform with UTF-8, there is a chance that it can't be decoded as such, in which case would print an error.

@gadomski , I tried to mimic the style/approach from the original code.